### PR TITLE
Introduce option which allows to ignore draft releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,17 @@ In this case, use `-e` command line option to extract some release tags by regul
 changelog-from-release -e '^v\d+\.\d+\.\d+$' > CHANGELOG.md
 ```
 
+### How to ignore draft releases?
+
+If you're using the GitHub Action and don't want draft releases to be included in the changelog, you can use the `-d` flag to omit them:
+
+```yaml
+- uses: rhysd/changelog-from-release/action@v3
+  with:
+    file: CHANGELOG.md
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    args: -d=false
+```
 
 ## Reference auto linking
 

--- a/changelog.go
+++ b/changelog.go
@@ -51,9 +51,6 @@ func (cl *ChangeLog) filterReleases(rels []*github.RepositoryRelease) []*github.
 // Generate generates changelog text from given releases and outputs it to its writer
 func (cl *ChangeLog) Generate(rels []*github.RepositoryRelease) error {
 	rels = cl.filterReleases(rels)
-	if len(rels) == 0 {
-		fail(fmt.Errorf("no releases to process, all filtered out"))
-	}
 
 	out := bufio.NewWriter(cl.out)
 	heading := strings.Repeat("#", cl.level)

--- a/changelog.go
+++ b/changelog.go
@@ -22,19 +22,23 @@ type ChangeLog struct {
 	repoURL string
 	out     io.Writer
 	level   int
+	drafts  bool
 	ignore  *regexp.Regexp
 	extract *regexp.Regexp
 }
 
 func (cl *ChangeLog) filterReleases(rels []*github.RepositoryRelease) []*github.RepositoryRelease {
-	if cl.ignore == nil && cl.extract == nil {
+	if cl.drafts && cl.ignore == nil && cl.extract == nil {
 		return rels
 	}
 
 	i := 0
 	for i < len(rels) {
-		t := rels[i].GetTagName()
-		if cl.ignore != nil && cl.ignore.MatchString(t) || cl.extract != nil && !cl.extract.MatchString(t) {
+		r := rels[i]
+		t := r.GetTagName()
+		if !cl.drafts && r.GetDraft() ||
+			cl.ignore != nil && cl.ignore.MatchString(t) ||
+			cl.extract != nil && !cl.extract.MatchString(t) {
 			rels = append(rels[:i], rels[i+1:]...)
 		} else {
 			i++
@@ -47,6 +51,9 @@ func (cl *ChangeLog) filterReleases(rels []*github.RepositoryRelease) []*github.
 // Generate generates changelog text from given releases and outputs it to its writer
 func (cl *ChangeLog) Generate(rels []*github.RepositoryRelease) error {
 	rels = cl.filterReleases(rels)
+	if len(rels) == 0 {
+		fail(fmt.Errorf("no releases to process, all filtered out"))
+	}
 
 	out := bufio.NewWriter(cl.out)
 	heading := strings.Repeat("#", cl.level)
@@ -111,8 +118,8 @@ func (cl *ChangeLog) Generate(rels []*github.RepositoryRelease) error {
 }
 
 // NewChangeLog creates a new ChangeLog instance
-func NewChangeLog(w io.Writer, u *url.URL, l int, i, e *regexp.Regexp) *ChangeLog {
+func NewChangeLog(w io.Writer, u *url.URL, l int, d bool, i, e *regexp.Regexp) *ChangeLog {
 	// Strip credentials in the repository URL (#9)
 	u.User = nil
-	return &ChangeLog{strings.TrimSuffix(u.String(), ".git"), w, l, i, e}
+	return &ChangeLog{strings.TrimSuffix(u.String(), ".git"), w, l, d, i, e}
 }

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ func main() {
 	flag.Usage = usage
 	ver := flag.Bool("v", false, "Output version to stdout")
 	heading := flag.Int("l", 1, "Heading level of each release section")
+	drafts := flag.Bool("d", true, "Include draft releases")
 	ignore := flag.String("i", "", "Pattern to ignore release tags in regular expression")
 	extract := flag.String("e", "", "Pattern to extract release tags in regular expression")
 	flag.Parse()
@@ -84,7 +85,7 @@ func main() {
 		fail(fmt.Errorf("no release was found at %s", url))
 	}
 
-	cl := NewChangeLog(os.Stdout, url, *heading, reIgnore, reExtract)
+	cl := NewChangeLog(os.Stdout, url, *heading, *drafts, reIgnore, reExtract)
 
 	if err := cl.Generate(rels); err != nil {
 		fail(err)


### PR DESCRIPTION
First of all, I'd like to thank you for providing this project :heart: 

In our case we don't want draft releases to be included in the changelog, therefore this pull request which introduces a new option (`-d` for drafts, defaults to true) allowing to ignore them.