### PR TITLE
use jq -r to strip quotes

### DIFF
--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -9,7 +9,7 @@ git config --global --add safe.directory /github/workspace
 cd "$GITHUB_WORKSPACE" || exit 1
 
 if [ -z "$INPUT_VERSION" ]; then
-    TAG_FROM_PAYLOAD="$(jq .release.tag_name < "$GITHUB_EVENT_PATH")"
+    TAG_FROM_PAYLOAD="$(jq -r .release.tag_name < "$GITHUB_EVENT_PATH")"
     if [ "$TAG_FROM_PAYLOAD" = "null" ]; then
         git fetch --prune --depth=1 origin '+refs/tags/*:refs/tags/*'
         INPUT_VERSION="$(git tag --list | tail -n 1)"


### PR DESCRIPTION
Use `jq -r .release.tag_name` in order to strip the extra quotes you get from `jq` otherwise.

Before a version could look like this: "1.2.3"
With this change it becomes: 1.2.3

This also affetcts branch names so instead of changelog-"1.2.3" we get changelog-1.2.3. This is good because fetching branches containing quotes can cause issues on Windows systems.