### PR TITLE
Add optional contributors section

### DIFF
--- a/changelog.go
+++ b/changelog.go
@@ -139,7 +139,7 @@ func processContributors(out *bytes.Buffer, usernames []string, p *Project, user
 	for _, username := range usernames {
 		if _, checked := userExists[username]; !checked {
 			profileImageURL := fmt.Sprintf("https://github.com/%s.png", username)
-			resp, err := http.Get(profileImageURL)
+			resp, err := http.Head(profileImageURL)
 			// Verify user exists to avoid 404 on image load
 			userExists[username] = err == nil && resp.StatusCode == http.StatusOK
 		}

--- a/changelog.go
+++ b/changelog.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -139,8 +138,9 @@ func processContributors(out *bytes.Buffer, usernames []string, p *Project, user
 	var contributors []string
 	for _, username := range usernames {
 		if _, checked := userExists[username]; !checked {
+			profileImageURL := fmt.Sprintf("https://github.com/%s.png", username)
+			resp, err := http.Get(profileImageURL)
 			// Verify user exists to avoid 404 on image load
-			_, resp, err := p.GitHub.api.Users.Get(context.TODO(), username)
 			userExists[username] = err == nil && resp.StatusCode == http.StatusOK
 		}
 		if userExists[username] {

--- a/changelog.go
+++ b/changelog.go
@@ -143,7 +143,7 @@ func GenerateChangeLog(c *Config, p *Project) ([]byte, error) {
 
 			// Add this to the Contributors section
 			if len(usernames) > 0 {
-				fmt.Fprintf(&out, "\n\n## Contributors\n\n")
+				fmt.Fprintf(&out, "\n\n## Contributors\n")
 
 				// Sort usernames for consistent output
 				sort.Strings(usernames)

--- a/github.go
+++ b/github.go
@@ -15,7 +15,6 @@ import (
 )
 
 type Project struct {
-	GitHub    *GitHub
 	Releases  []*github.RepositoryRelease
 	Autolinks []*github.Autolink
 	Remote    *url.URL
@@ -114,7 +113,6 @@ func (gh *GitHub) Project() (*Project, error) {
 	}
 
 	return &Project{
-		GitHub:    gh,
 		Releases:  rs,
 		Autolinks: ls,
 		Remote:    gh.url,

--- a/github.go
+++ b/github.go
@@ -114,10 +114,10 @@ func (gh *GitHub) Project() (*Project, error) {
 	}
 
 	return &Project{
+		GitHub:    gh,
 		Releases:  rs,
 		Autolinks: ls,
 		Remote:    gh.url,
-		GitHub:    gh,
 	}, nil
 }
 

--- a/github.go
+++ b/github.go
@@ -15,6 +15,7 @@ import (
 )
 
 type Project struct {
+	GitHub    *GitHub
 	Releases  []*github.RepositoryRelease
 	Autolinks []*github.Autolink
 	Remote    *url.URL
@@ -116,6 +117,7 @@ func (gh *GitHub) Project() (*Project, error) {
 		Releases:  rs,
 		Autolinks: ls,
 		Remote:    gh.url,
+		GitHub:    gh,
 	}, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func main() {
 	ignore := flag.String("i", "", "Pattern to ignore release tags in regular expression")
 	extract := flag.String("e", "", "Pattern to extract release tags in regular expression")
 	remote := flag.String("r", "", "Remote repository URL to generate changelog")
-	contrib := flag.Bool("c", false, "Include contributors in the output")
+	contrib := flag.Bool("c", false, "Include contributors section")
 	debug := flag.Bool("debug", false, "Enable debug log")
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ func main() {
 	ignore := flag.String("i", "", "Pattern to ignore release tags in regular expression")
 	extract := flag.String("e", "", "Pattern to extract release tags in regular expression")
 	remote := flag.String("r", "", "Remote repository URL to generate changelog")
+	contrib := flag.Bool("c", false, "Include contributors in the output")
 	debug := flag.Bool("debug", false, "Enable debug log")
 	flag.Parse()
 
@@ -103,11 +104,12 @@ func main() {
 		fail(err)
 	}
 	cfg := &Config{
-		Level:      *heading,
-		Drafts:     *drafts,
-		Prerelease: *prerelease,
-		Ignore:     reIgnore,
-		Extract:    reExtract,
+		Level:        *heading,
+		Drafts:       *drafts,
+		Prerelease:   *prerelease,
+		Ignore:       reIgnore,
+		Extract:      reExtract,
+		Contributors: *contrib,
 	}
 	slog.Debug("Arguments parsed:", "config", cfg)
 

--- a/reflink.go
+++ b/reflink.go
@@ -435,7 +435,7 @@ func (l *Reflinker) Link(input string) string {
 	return l.applyReplacements()
 }
 
-// Usernames returns all user names found in the markdown text.
+// Usernames returns all usernames found in the markdown text.
 func (l *Reflinker) Usernames() []string {
 	users := make([]string, 0, len(l.users))
 	for u := range l.users {


### PR DESCRIPTION
Thank you for creating this valuable tool. I wanted to add a contributors section to recognize and acknowledge contributors, which isn't automatically generated by the GitHub releases page.

This PR adds an optional feature to display contributors for each release in the changelog.

Changes:
- Add `-c` flag to enable the contributors feature
- Extract GitHub usernames from release text
- Validate that user accounts still exist to avoid 404
- Output "Contributors" section and a list of profile images

The implementation only runs when the `-c` flag is specified. When enabled, it finds mentions of GitHub users in release notes and displays them with their profile pictures.

Example output (when `-c` flag is used):

```md
## Contributors

<a href="https://github.com/yottahmd"><img src="https://wsrv.nl/?url=https://github.com/yottahmd.png&w=64&h=64&fit=cover&mask=circle" width="64" height="64" alt="@yottahmd"></a> 
```

Example CHANGELOG.md:
https://github.com/dagu-org/dagu/blob/main/CHANGELOG.md